### PR TITLE
Build updates to compile on Scala 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>lambda-calculus</artifactId>
 	<version>1.0</version>
 	<properties>
-		<scala.version>2.10.1</scala.version>
+		<scala.version>2.12.1</scala.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<dependencies>
@@ -13,6 +13,11 @@
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-library</artifactId>
 			<version>${scala.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.scala-lang.modules</groupId>
+			<artifactId>scala-parser-combinators_2.12</artifactId>
+			<version>1.0.5</version>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
The scala parser combinators now come as a separate dependency.  I've added these to the pom.xml.